### PR TITLE
Add tilde ('~') character support

### DIFF
--- a/src/DotNet.Glob/GlobStringReader.cs
+++ b/src/DotNet.Glob/GlobStringReader.cs
@@ -24,7 +24,7 @@ namespace DotNet.Globbing
         //public const char HashChar = '#';
 
 
-        public static char[] AllowedNonAlphaNumericChars = new[] { '.', ' ', '!', '#', '-', ';', '=', '@' };
+        public static char[] AllowedNonAlphaNumericChars = new[] { '.', ' ', '!', '#', '-', ';', '=', '@', '~' };
 
         /// <summary>
         /// The current delimiters


### PR DESCRIPTION
Although ~ has special functions on Linux (see GLOB_TILDE in http://man7.org/linux/man-pages/man3/glob.3.html), it is commonly used in ignore patterns. For example, Unity use *~/ as hidden folders (see Hidden Assets in  https://docs.unity3d.com/Manual/SpecialFolders.html).

Please add the support of this character in DotNet Glob.