### PR TITLE
Case insensitivity option (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ In addition, DotNet Glob also supports:
 | `**` |  matches any number of path / directory segments. When used must be the only contents of a segment. | /\*\*/some.\* | /foo/bar/bah/some.txt, /some.txt, or /foo/some.txt	|
 
 
-
-
 # Advanced Usages
 
 ## Parsing options.
@@ -82,17 +80,36 @@ However, introduced in version `1.6.4`, you can override this behaviour so that 
 
 ```csharp
     // Overide the default options globally for all matche:
-    GlobParseOptions.Default.AllowInvalidPathCharacters = true;
+    GlobParseOptions.Default.Parsing.AllowInvalidPathCharacters = true;
     DotNet.Globbing.Glob.Parse("\"Stuff*").IsMatch("\"Stuff"); // true;    
 ```
 
 You can also just set these options on a per glob pattern basis:
 
 ```csharp
-    var globParseOptions = new GlobParseOptions() { AllowInvalidPathCharacters = true };
+    GlobOptions options = new GlobOptions();
+    options.Parsing.AllowInvalidPathCharacters = allowInvalidPathCharcters;
     DotNet.Globbing.Glob.Parse("\"Stuff*", globParseOptions).IsMatch("\"Stuff"); // true; 
 
 ```
+
+## Case Sensitivity
+
+By default, evaluation is case-sensitive unless you specify otherwise.
+
+```csharp
+    GlobOptions options = new GlobOptions();
+    options.Evaluation.CaseInsensitive = true;
+    DotNet.Globbing.Glob.Parse("foo*", globParseOptions).IsMatch("FOo"); // true; 
+
+```
+
+Setting CaseInsensitive has an impact on:
+
+- Letter Ranges. Any letter range (i.e '[A-Z]') will now match both lower or upper case characters.
+- Character Lists. Any character list (i.e '[ABC]') will now match both lower or upper case characters.
+- Literals. Any literal (i.e 'foo') will now match both lower or upper case characters i.e `FoO` will match `foO` etc.
+
 
 ## Match Generation
 Given a glob, you can generate random matches, or non matches, for that glob.

--- a/src/DotNet.Glob.Benchmarks/Utils/GlobToRegexFormatter.cs
+++ b/src/DotNet.Glob.Benchmarks/Utils/GlobToRegexFormatter.cs
@@ -46,7 +46,7 @@ namespace DotNet.Glob.Benchmarks.Utils
             {
                 _stringBuilder.Append('^');
             }
-            _stringBuilder.Append(Regex.Escape(new string(token.Characters.ToArray())));
+            _stringBuilder.Append(Regex.Escape(new string(token.Characters)));
             _stringBuilder.Append(']');
 
         }

--- a/src/DotNet.Glob.Tests/FormatterTests.cs
+++ b/src/DotNet.Glob.Tests/FormatterTests.cs
@@ -14,15 +14,16 @@ namespace DotNet.Glob.Tests
             // build the following glob pattern using tokens:
             //       /foo?\\*[abc][!1-3].txt
 
-            var glob = new Globbing.Glob(new PathSeperatorToken('/'),
-                                new LiteralToken("foo"),
-                                new AnyCharacterToken(),
-                                new PathSeperatorToken('\\'),
-                                new WildcardToken(),
-                                new CharacterListToken(new char[] { 'a', 'b', 'c' }, false),                                
-                                new WildcardDirectoryToken(new PathSeperatorToken('/'), new PathSeperatorToken('/')),                              
-                                new NumberRangeToken('1', '3', true),
-                                new LiteralToken(".txt"));
+            var glob = new Globbing.Glob(false, 
+                new PathSeperatorToken('/'),
+                new LiteralToken("foo"),
+                new AnyCharacterToken(),
+                new PathSeperatorToken('\\'),
+                new WildcardToken(),
+                new CharacterListToken(new char[] { 'a', 'b', 'c' }, false),
+                new WildcardDirectoryToken(new PathSeperatorToken('/'), new PathSeperatorToken('/')),
+                new NumberRangeToken('1', '3', true),
+                new LiteralToken(".txt"));
 
             // now format the glob.
             var sut = new GlobTokenFormatter();

--- a/src/DotNet.Glob.Tests/FormatterTests.cs
+++ b/src/DotNet.Glob.Tests/FormatterTests.cs
@@ -14,7 +14,7 @@ namespace DotNet.Glob.Tests
             // build the following glob pattern using tokens:
             //       /foo?\\*[abc][!1-3].txt
 
-            var glob = new Globbing.Glob(false, 
+            var glob = new Globbing.Glob(
                 new PathSeperatorToken('/'),
                 new LiteralToken("foo"),
                 new AnyCharacterToken(),

--- a/src/DotNet.Glob.Tests/GlobTests.cs
+++ b/src/DotNet.Glob.Tests/GlobTests.cs
@@ -21,9 +21,16 @@ namespace DotNet.Glob.Tests
         [InlineData("C:\\name\\**", false, "C:\\name.ext", "C:\\name_longer.ext")] // Regression Test for https://github.com/dazinator/DotNet.Glob/issues/29
         [InlineData("Bumpy/**/AssemblyInfo.cs", false, "Bumpy.Test/Properties/AssemblyInfo.cs")]      // Regression Test for https://github.com/dazinator/DotNet.Glob/issues/33
         [InlineData("C:\\sources\\x-y 1\\BIN\\DEBUG\\COMPILE\\**\\MSVC*120.DLL", false, "C:\\sources\\x-y 1\\BIN\\DEBUG\\COMPILE\\ANTLR3.RUNTIME.DLL")]      // Attempted repro for https://github.com/dazinator/DotNet.Glob/issues/37
+        [InlineData("literal1", false, "LITERAL1")] // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
+        [InlineData("*ral*", false, "LITERAL1")] // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
+        [InlineData("[list]s", false, "LS", "iS", "Is")] // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
+        [InlineData("range/[a-b][C-D]", false, "range/ac", "range/Ad", "range/BD")] // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
         public void Does_Not_Match(string pattern, bool allowInvalidPathCharcters, params string[] testStrings)
         {
-            GlobParseOptions options = new GlobParseOptions() { AllowInvalidPathCharacters = allowInvalidPathCharcters };
+            GlobParseOptions options = new GlobParseOptions()
+            {
+                AllowInvalidPathCharacters = allowInvalidPathCharcters
+            };
             var glob = Globbing.Glob.Parse(pattern, options);
             foreach (var testString in testStrings)
             {
@@ -63,8 +70,11 @@ namespace DotNet.Glob.Tests
         public void IsMatch(string pattern, params string[] testStrings)
         {
 
-            GlobParseOptions.Default.AllowInvalidPathCharacters = true;
-            var glob = Globbing.Glob.Parse(pattern);
+            GlobParseOptions options = new GlobParseOptions()
+            {
+                AllowInvalidPathCharacters = true
+            };
+            var glob = Globbing.Glob.Parse(pattern, options);
             foreach (var testString in testStrings)
             {
                 var match = glob.IsMatch(testString);
@@ -73,6 +83,26 @@ namespace DotNet.Glob.Tests
             }
         }
 
+        // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
+        [Theory]
+        [InlineData("literal1", "LITERAL1", "literal1")]
+        [InlineData("*ral*", "LITERAL1", "literal1")]
+        [InlineData("[list]s", "LS", "ls", "iS", "Is")]
+        [InlineData("range/[a-b][C-D]", "range/ac", "range/Ad", "range/bC", "range/BD")]
+        public void IsMatchCaseInsensitive(string pattern, params string[] testStrings)
+        {
+            GlobParseOptions options = new GlobParseOptions()
+            {
+                CaseInsensitive = true,
+                AllowInvalidPathCharacters = true
+            };
+            var glob = Globbing.Glob.Parse(pattern, options);
+            foreach (var testString in testStrings)
+            {
+                var match = glob.IsMatch(testString);
+                Assert.True(match);
+            }
+        }
 
         [Fact]
         public void To_String_Returns_Pattern()

--- a/src/DotNet.Glob.Tests/GlobTests.cs
+++ b/src/DotNet.Glob.Tests/GlobTests.cs
@@ -27,10 +27,9 @@ namespace DotNet.Glob.Tests
         [InlineData("range/[a-b][C-D]", false, "range/ac", "range/Ad", "range/BD")] // Regression tests for https://github.com/dazinator/DotNet.Glob/issues/41
         public void Does_Not_Match(string pattern, bool allowInvalidPathCharcters, params string[] testStrings)
         {
-            GlobParseOptions options = new GlobParseOptions()
-            {
-                AllowInvalidPathCharacters = allowInvalidPathCharcters
-            };
+            GlobOptions options = new GlobOptions();
+            options.Parsing.AllowInvalidPathCharacters = allowInvalidPathCharcters;
+           
             var glob = Globbing.Glob.Parse(pattern, options);
             foreach (var testString in testStrings)
             {
@@ -70,10 +69,9 @@ namespace DotNet.Glob.Tests
         public void IsMatch(string pattern, params string[] testStrings)
         {
 
-            GlobParseOptions options = new GlobParseOptions()
-            {
-                AllowInvalidPathCharacters = true
-            };
+            GlobOptions options = new GlobOptions();
+            options.Parsing.AllowInvalidPathCharacters = true;
+           
             var glob = Globbing.Glob.Parse(pattern, options);
             foreach (var testString in testStrings)
             {
@@ -91,11 +89,10 @@ namespace DotNet.Glob.Tests
         [InlineData("range/[a-b][C-D]", "range/ac", "range/Ad", "range/bC", "range/BD")]
         public void IsMatchCaseInsensitive(string pattern, params string[] testStrings)
         {
-            GlobParseOptions options = new GlobParseOptions()
-            {
-                CaseInsensitive = true,
-                AllowInvalidPathCharacters = true
-            };
+            GlobOptions options = new GlobOptions();
+            options.Parsing.AllowInvalidPathCharacters = true;
+            options.Evaluation.CaseInsensitive = true;
+           
             var glob = Globbing.Glob.Parse(pattern, options);
             foreach (var testString in testStrings)
             {

--- a/src/DotNet.Glob/DotNet.Glob.csproj
+++ b/src/DotNet.Glob/DotNet.Glob.csproj
@@ -16,4 +16,9 @@
     <PackageReleaseNotes>This is a hotfix release to support tilde characters (~), thanks goes to @ming4883</PackageReleaseNotes>
     <RootNamespace>DotNet.Glob</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup Condition="  '$(TargetFramework)' == 'net4' ">
+    <DefineConstants>NET40</DefineConstants>   
+  </PropertyGroup>
+  
 </Project>

--- a/src/DotNet.Glob/Evaluation/AnyCharacterTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/AnyCharacterTokenEvaluator.cs
@@ -11,6 +11,7 @@ namespace DotNet.Globbing.Evaluation
         {
             _token = token;
         }
+
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
         {
             newPosition = currentPosition + 1;

--- a/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluator.cs
@@ -4,19 +4,33 @@ namespace DotNet.Globbing.Evaluation
 {
     public class CharacterListTokenEvaluator : IGlobTokenEvaluator
     {
+        private readonly bool _caseInsensitive;
         private readonly CharacterListToken _token;
 
-        public CharacterListTokenEvaluator(CharacterListToken token)
+        public CharacterListTokenEvaluator(CharacterListToken token, bool caseInsensitive)
         {
+            _caseInsensitive = caseInsensitive;
             _token = token;
         }
+
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
         {
             var currentChar = allChars[currentPosition];
             newPosition = currentPosition + 1;
 
             //var currentChar = (char)read;
-            var contains = _token.Characters.Contains(currentChar);
+            bool contains;
+            if (_caseInsensitive)
+            {
+                // compare characters as lower case using invariant culture (case insensitive)
+                contains = _token.CharactersInvariantLowerCase.Contains(char.ToLowerInvariant(currentChar));
+            }
+            else
+            {
+                // compare characters as-is (case sensitive)
+                contains = _token.Characters.Contains(currentChar);
+            }
+
             if (_token.IsNegated)
             {
                 if (contains)

--- a/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluatorCaseInsensitive.cs
@@ -1,17 +1,25 @@
 using DotNet.Globbing.Token;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace DotNet.Globbing.Evaluation
 {
 
-    public class CharacterListTokenEvaluator : IGlobTokenEvaluator
+    public class CharacterListTokenEvaluatorCaseInsensitive : IGlobTokenEvaluator
     {
         private readonly CharacterListToken _token;
+        private readonly char[] _charactersAsUpperInvariant;
 
-
-        public CharacterListTokenEvaluator(CharacterListToken token)
-        {
+        public CharacterListTokenEvaluatorCaseInsensitive(CharacterListToken token)
+        {           
             _token = token;
+
+            _charactersAsUpperInvariant = new char[token.Characters.Length];
+            for (int i = 0; i < token.Characters.Length; i++)
+            {
+                var tokenChar = token.Characters[i];
+                _charactersAsUpperInvariant[i] = Char.ToUpperInvariant(tokenChar);
+            }
         }
 
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
@@ -36,9 +44,11 @@ namespace DotNet.Globbing.Evaluation
 #endif
         private bool IsMatch(char containsChar)
         {
-            foreach (var item in _token.Characters)
+            var upperInvariantChar = Char.ToUpperInvariant(containsChar);
+
+            foreach (var item in _charactersAsUpperInvariant)
             {
-                if (item.Equals(containsChar))
+                if (item.Equals(upperInvariantChar))
                 {
                     return true;
                 }

--- a/src/DotNet.Glob/Evaluation/GlobTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/GlobTokenEvaluator.cs
@@ -11,9 +11,9 @@ namespace DotNet.Globbing.Evaluation
 
         private readonly CompositeTokenEvaluator _rootTokenEvaluator;
 
-        public GlobTokenEvaluator(IGlobToken[] tokens)
+        public GlobTokenEvaluator(bool caseInsensitive, IGlobToken[] tokens)
         {
-            _rootTokenEvaluator = new CompositeTokenEvaluator(tokens);
+            _rootTokenEvaluator = new CompositeTokenEvaluator(tokens, caseInsensitive);
         }
 
         public bool IsMatch(string text)

--- a/src/DotNet.Glob/Evaluation/GlobTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/GlobTokenEvaluator.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using DotNet.Globbing.Token;
 
 namespace DotNet.Globbing.Evaluation
@@ -10,10 +9,12 @@ namespace DotNet.Globbing.Evaluation
         public int _currentChar;
 
         private readonly CompositeTokenEvaluator _rootTokenEvaluator;
-
-        public GlobTokenEvaluator(bool caseInsensitive, IGlobToken[] tokens)
+        private readonly EvaluationOptions _options;
+     
+        public GlobTokenEvaluator(EvaluationOptions options, IGlobToken[] tokens)
         {
-            _rootTokenEvaluator = new CompositeTokenEvaluator(tokens, caseInsensitive);
+            _options = options;        
+            _rootTokenEvaluator = new CompositeTokenEvaluator(tokens, options.GetTokenEvaluatorFactory());
         }
 
         public bool IsMatch(string text)
@@ -24,4 +25,5 @@ namespace DotNet.Globbing.Evaluation
         }
 
     }
+
 }

--- a/src/DotNet.Glob/Evaluation/GlobTokenEvaluatorFactory.cs
+++ b/src/DotNet.Glob/Evaluation/GlobTokenEvaluatorFactory.cs
@@ -1,0 +1,70 @@
+﻿using DotNet.Globbing.Token;
+
+namespace DotNet.Globbing.Evaluation
+{
+    public class GlobTokenEvaluatorFactory : IGlobTokenEvaluatorFactory
+    {
+        private readonly EvaluationOptions _options;
+
+        public GlobTokenEvaluatorFactory(EvaluationOptions options)
+        {
+            _options = options;
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(AnyCharacterToken token)
+        {
+            return new AnyCharacterTokenEvaluator(token);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(CharacterListToken token)
+        {
+            // ICharacterMatcher matcher;
+            if (_options.CaseInsensitive)
+            {
+                return new CharacterListTokenEvaluatorCaseInsensitive(token);
+            }
+
+            return new CharacterListTokenEvaluator(token);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(LetterRangeToken token)
+        {
+            if (_options.CaseInsensitive)
+            {
+                return new LetterRangeTokenEvaluatorCaseInsensitive(token);
+            }
+            return new LetterRangeTokenEvaluator(token);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(LiteralToken token)
+        {
+            if (_options.CaseInsensitive)
+            {
+                return new LiteralTokenEvaluatorCaseInsensitive(token);
+            }
+
+            return new LiteralTokenEvaluator(token);
+
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(NumberRangeToken token)
+        {
+            return new NumberRangeTokenEvaluator(token);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(PathSeperatorToken token)
+        {
+            return new PathSeperatorTokenEvaluator(token);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(WildcardDirectoryToken token, CompositeTokenEvaluator nestedCompositeTokenEvaluator)
+        {
+            return new WildcardDirectoryTokenEvaluator(token, nestedCompositeTokenEvaluator);
+        }
+
+        public IGlobTokenEvaluator CreateTokenEvaluator(WildcardToken token, CompositeTokenEvaluator nestedCompositeTokenEvaluator)
+        {
+            return new WildcardTokenEvaluator(token, nestedCompositeTokenEvaluator);
+        }
+    }
+}

--- a/src/DotNet.Glob/Evaluation/IGlobTokenEvaluatorFactory.cs
+++ b/src/DotNet.Glob/Evaluation/IGlobTokenEvaluatorFactory.cs
@@ -1,0 +1,18 @@
+﻿using DotNet.Globbing.Token;
+
+namespace DotNet.Globbing.Evaluation
+{
+    public interface IGlobTokenEvaluatorFactory
+    {
+        IGlobTokenEvaluator CreateTokenEvaluator(AnyCharacterToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(CharacterListToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(LetterRangeToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(LiteralToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(NumberRangeToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(PathSeperatorToken token);
+        IGlobTokenEvaluator CreateTokenEvaluator(WildcardDirectoryToken token, CompositeTokenEvaluator nestedCompositeTokenEvaluator);
+        IGlobTokenEvaluator CreateTokenEvaluator(WildcardToken token, CompositeTokenEvaluator nestedCompositeTokenEvaluator);
+
+    }
+
+}

--- a/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
@@ -4,19 +4,33 @@ namespace DotNet.Globbing.Evaluation
 {
     public class LetterRangeTokenEvaluator : IGlobTokenEvaluator
     {
+        private readonly bool _caseInsensitive;
         private readonly LetterRangeToken _token;
 
-        public LetterRangeTokenEvaluator(LetterRangeToken token)
+        public LetterRangeTokenEvaluator(LetterRangeToken token, bool caseInsensitive)
         {
+            _caseInsensitive = caseInsensitive;
             _token = token;
         }
+
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
         {
-            var currentChar = allChars[currentPosition];
             newPosition = currentPosition + 1;
 
             //var currentChar = (char)read;
-            if (currentChar >= _token.Start && currentChar <= _token.End)
+            char start, end, currentChar;
+            start = _token.Start;
+            end = _token.End;
+            currentChar = allChars[currentPosition];
+
+            if (_caseInsensitive)
+            {
+                start = char.ToLowerInvariant(start);
+                end = char.ToLowerInvariant(end);
+                currentChar = char.ToLowerInvariant(currentChar);
+            }
+
+            if (currentChar >= start && currentChar <= end)
             {
                 if (_token.IsNegated)
                 {
@@ -33,8 +47,6 @@ namespace DotNet.Globbing.Evaluation
 
             return true;
             // this.Success = true;
-
-
         }
 
         public virtual int ConsumesMinLength
@@ -48,5 +60,5 @@ namespace DotNet.Globbing.Evaluation
         }
     }
 
-  
+
 }

--- a/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
@@ -1,52 +1,40 @@
 using DotNet.Globbing.Token;
+using System.Runtime.CompilerServices;
 
 namespace DotNet.Globbing.Evaluation
 {
     public class LetterRangeTokenEvaluator : IGlobTokenEvaluator
-    {
-        private readonly bool _caseInsensitive;
+    {     
         private readonly LetterRangeToken _token;
 
-        public LetterRangeTokenEvaluator(LetterRangeToken token, bool caseInsensitive)
-        {
-            _caseInsensitive = caseInsensitive;
+        public LetterRangeTokenEvaluator(LetterRangeToken token)
+        {          
             _token = token;
         }
 
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
         {
-            newPosition = currentPosition + 1;
-
-            //var currentChar = (char)read;
-            char start, end, currentChar;
-            start = _token.Start;
-            end = _token.End;
+            newPosition = currentPosition + 1;           
+            char currentChar;          
             currentChar = allChars[currentPosition];
+            return IsMatch(currentChar);
+        }
 
-            if (_caseInsensitive)
-            {
-                start = char.ToLowerInvariant(start);
-                end = char.ToLowerInvariant(end);
-                currentChar = char.ToLowerInvariant(currentChar);
-            }
+#if !NET40
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private bool IsMatch(char testChar)
+        {
+            bool isMatch = testChar >= _token.Start && testChar <= _token.End;
 
-            if (currentChar >= start && currentChar <= end)
+            if (_token.IsNegated)
             {
-                if (_token.IsNegated)
-                {
-                    return false; // failed to match
-                }
+                return !isMatch;
             }
             else
             {
-                if (!_token.IsNegated)
-                {
-                    return false; // failed to match
-                }
+                return isMatch;
             }
-
-            return true;
-            // this.Success = true;
         }
 
         public virtual int ConsumesMinLength

--- a/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluatorCaseInsensitive.cs
@@ -1,0 +1,61 @@
+﻿using DotNet.Globbing.Token;
+using System.Runtime.CompilerServices;
+
+namespace DotNet.Globbing.Evaluation
+{
+    public class LetterRangeTokenEvaluatorCaseInsensitive : IGlobTokenEvaluator
+    {
+        private readonly LetterRangeToken _token;
+        private readonly char _startUpperInvariant;
+        private readonly char _endUpperInvariant;
+        private readonly char _startLowerInvariant;
+        private readonly char _endLowerInvariant;
+        
+        public LetterRangeTokenEvaluatorCaseInsensitive(LetterRangeToken token)
+        {
+            _token = token;
+            _startUpperInvariant = char.ToUpperInvariant(token.Start);
+            _endUpperInvariant = char.ToUpperInvariant(token.End);
+            _startLowerInvariant = char.ToLowerInvariant(token.Start);
+            _endLowerInvariant = char.ToLowerInvariant(token.End);
+        }
+
+        public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+        {
+            newPosition = currentPosition + 1;
+            char currentChar;
+            currentChar = allChars[currentPosition];
+            return IsMatch(currentChar);
+        }
+
+#if !NET40
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private bool IsMatch(char containsChar)
+        {
+            bool isMatch = (containsChar >= _startUpperInvariant && containsChar <= _endUpperInvariant)
+                || (containsChar >= _startLowerInvariant && containsChar <= _endLowerInvariant);
+
+            if (_token.IsNegated)
+            {
+                return !isMatch;
+            }
+            else
+            {
+                return isMatch;
+            }
+        }
+
+        public virtual int ConsumesMinLength
+        {
+            get { return 1; }
+        }
+
+        public bool ConsumesVariableLength
+        {
+            get { return false; }
+        }
+    }
+
+
+}

--- a/src/DotNet.Glob/Evaluation/LiteralTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/LiteralTokenEvaluator.cs
@@ -4,11 +4,13 @@ namespace DotNet.Globbing.Evaluation
 {
     public class LiteralTokenEvaluator : IGlobTokenEvaluator
     {
+        private readonly bool _caseInsensitive;
         private readonly LiteralToken _token;
 
-        public LiteralTokenEvaluator(LiteralToken token)
+        public LiteralTokenEvaluator(LiteralToken token, bool caseInsensitive)
         {
             _token = token;
+            _caseInsensitive = caseInsensitive;
         }
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
         {
@@ -19,6 +21,12 @@ namespace DotNet.Globbing.Evaluation
             {
                 var compareChar = _token.Value[counter];
                 var currentChar = allChars[newPosition];
+
+                if (_caseInsensitive)
+                {
+                    compareChar = char.ToLowerInvariant(compareChar);
+                    currentChar = char.ToLowerInvariant(currentChar);
+                }
 
                 if (compareChar != currentChar)
                 {

--- a/src/DotNet.Glob/Evaluation/LiteralTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/LiteralTokenEvaluatorCaseInsensitive.cs
@@ -1,16 +1,19 @@
-using DotNet.Globbing.Token;
+﻿using DotNet.Globbing.Token;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace DotNet.Globbing.Evaluation
 {
-    public class LiteralTokenEvaluator : IGlobTokenEvaluator
+    public class LiteralTokenEvaluatorCaseInsensitive : IGlobTokenEvaluator
     {
-       
-        private readonly LiteralToken _token;
 
-        public LiteralTokenEvaluator(LiteralToken token)
+        private readonly LiteralToken _token;
+        private readonly string _literalAsUpperInvariant;
+
+        public LiteralTokenEvaluatorCaseInsensitive(LiteralToken token)
         {
-            _token = token;           
+            _token = token;
+            _literalAsUpperInvariant = token.Value.ToUpperInvariant();
         }
 
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
@@ -19,9 +22,9 @@ namespace DotNet.Globbing.Evaluation
             int counter = 0;
 
             while (newPosition < allChars.Length && counter < _token.Value.Length)
-            {               
+            {
                 var currentChar = allChars[newPosition];
-                if(!IsMatch(currentChar, counter))
+                if (!IsMatch(currentChar, counter))
                 {
                     return false;
                 }
@@ -34,16 +37,18 @@ namespace DotNet.Globbing.Evaluation
             {
                 return false;
             }
-          
+
             return true;
         }
 
 #if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        private bool IsMatch(char containsChar, int position)
+        public bool IsMatch(char containsChar, int position)
         {
-            return containsChar == _token.Value[position];
+            var upperInvariantChar = Char.ToUpperInvariant(containsChar);
+            var comparisonChar = _literalAsUpperInvariant[position];
+            return upperInvariantChar == comparisonChar;
         }
 
         public virtual int ConsumesMinLength

--- a/src/DotNet.Glob/EvaluationOptions.cs
+++ b/src/DotNet.Glob/EvaluationOptions.cs
@@ -1,0 +1,20 @@
+﻿using DotNet.Globbing.Evaluation;
+
+namespace DotNet.Globbing
+{
+    public class EvaluationOptions
+    {
+        public EvaluationOptions()
+        {
+            CaseInsensitive = false;
+        }
+
+        public bool CaseInsensitive { get; set; }
+
+        public virtual IGlobTokenEvaluatorFactory GetTokenEvaluatorFactory()
+        {
+            return new GlobTokenEvaluatorFactory(this);
+        }
+    }
+
+}

--- a/src/DotNet.Glob/Glob.cs
+++ b/src/DotNet.Glob/Glob.cs
@@ -12,12 +12,14 @@ namespace DotNet.Globbing
         private GlobTokenFormatter _Formatter;
         private string _pattern;
         private readonly GlobTokenEvaluator _isMatchEvaluator;
-      
-        public Glob(params IGlobToken[] tokens)
+        private readonly bool _caseInsensitive;
+
+        public Glob(bool caseInsensitive, params IGlobToken[] tokens)
         {
             Tokens = tokens;
+            _caseInsensitive = caseInsensitive;
             _Formatter = new GlobTokenFormatter();
-            _isMatchEvaluator = new GlobTokenEvaluator(Tokens);        
+            _isMatchEvaluator = new GlobTokenEvaluator(_caseInsensitive, Tokens);
         }
 
         public static Glob Parse(string pattern)
@@ -34,7 +36,7 @@ namespace DotNet.Globbing
             }
             var tokeniser = new GlobTokeniser();
             var tokens = tokeniser.Tokenise(pattern, options.AllowInvalidPathCharacters);
-            return new Glob(tokens.ToArray());
+            return new Glob(options.CaseInsensitive, tokens.ToArray());
         }
 
         public bool IsMatch(string subject)

--- a/src/DotNet.Glob/Glob.cs
+++ b/src/DotNet.Glob/Glob.cs
@@ -12,37 +12,41 @@ namespace DotNet.Globbing
         private GlobTokenFormatter _Formatter;
         private string _pattern;
         private readonly GlobTokenEvaluator _isMatchEvaluator;
-        private readonly bool _caseInsensitive;
+        private readonly GlobOptions _options;
 
-        public Glob(bool caseInsensitive, params IGlobToken[] tokens)
+        public Glob(params IGlobToken[] tokens) : this(GlobOptions.Default, tokens)
+        {
+        }
+
+        public Glob(GlobOptions options = null, params IGlobToken[] tokens)
         {
             Tokens = tokens;
-            _caseInsensitive = caseInsensitive;
+            _options = options ?? GlobOptions.Default;
             _Formatter = new GlobTokenFormatter();
-            _isMatchEvaluator = new GlobTokenEvaluator(_caseInsensitive, Tokens);
+            _isMatchEvaluator = new GlobTokenEvaluator(options.Evaluation, Tokens);
         }
 
         public static Glob Parse(string pattern)
         {
-            var options = GlobParseOptions.Default;
+            var options = GlobOptions.Default;
             return Parse(pattern, options);
         }
 
-        public static Glob Parse(string pattern, GlobParseOptions options)
+        public static Glob Parse(string pattern, GlobOptions options)
         {
             if (string.IsNullOrEmpty(pattern))
             {
                 throw new ArgumentNullException(pattern);
             }
             var tokeniser = new GlobTokeniser();
-            var tokens = tokeniser.Tokenise(pattern, options.AllowInvalidPathCharacters);
-            return new Glob(options.CaseInsensitive, tokens.ToArray());
+            var tokens = tokeniser.Tokenise(pattern, options.Parsing.AllowInvalidPathCharacters);
+            return new Glob(options, tokens.ToArray());
         }
 
         public bool IsMatch(string subject)
         {
             return _isMatchEvaluator.IsMatch(subject);
-        }      
+        }
 
         public override string ToString()
         {

--- a/src/DotNet.Glob/GlobBuilder.cs
+++ b/src/DotNet.Glob/GlobBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using DotNet.Globbing.Token;
 
 namespace DotNet.Globbing
@@ -9,12 +7,10 @@ namespace DotNet.Globbing
     public class GlobBuilder : IGlobBuilder
     {
         private readonly List<IGlobToken> _tokens;
-        private bool _caseInsensitive;
 
-        public GlobBuilder(bool caseInsensitive = false)
+        public GlobBuilder()
         {
-            _tokens = new List<IGlobToken>();
-            _caseInsensitive = caseInsensitive;
+            _tokens = new List<IGlobToken>();           
         }
 
         public IGlobBuilder AnyCharacter()
@@ -139,9 +135,9 @@ namespace DotNet.Globbing
             return this;
         }
 
-        public Glob ToGlob()
+        public Glob ToGlob(GlobOptions options = null)
         {
-            return new Glob(_caseInsensitive, _tokens.ToArray());
+            return new Glob(options ?? GlobOptions.Default, _tokens.ToArray());
         }
 
         public List<IGlobToken> Tokens

--- a/src/DotNet.Glob/GlobBuilder.cs
+++ b/src/DotNet.Glob/GlobBuilder.cs
@@ -9,10 +9,12 @@ namespace DotNet.Globbing
     public class GlobBuilder : IGlobBuilder
     {
         private readonly List<IGlobToken> _tokens;
+        private bool _caseInsensitive;
 
-        public GlobBuilder()
+        public GlobBuilder(bool caseInsensitive = false)
         {
             _tokens = new List<IGlobToken>();
+            _caseInsensitive = caseInsensitive;
         }
 
         public IGlobBuilder AnyCharacter()
@@ -139,7 +141,7 @@ namespace DotNet.Globbing
 
         public Glob ToGlob()
         {
-            return new Glob(this._tokens.ToArray());
+            return new Glob(_caseInsensitive, _tokens.ToArray());
         }
 
         public List<IGlobToken> Tokens

--- a/src/DotNet.Glob/GlobOptions.cs
+++ b/src/DotNet.Glob/GlobOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace DotNet.Globbing
+{
+    public class GlobOptions
+    {
+        public GlobOptions()
+        {
+            Parsing = new ParsingOptions();
+            Evaluation = new EvaluationOptions();           
+        }
+
+        public static GlobOptions Default = new GlobOptions();
+
+        public ParsingOptions Parsing { get; set; }
+
+        public EvaluationOptions Evaluation { get; set; }
+    }
+}

--- a/src/DotNet.Glob/GlobParseOptions.cs
+++ b/src/DotNet.Glob/GlobParseOptions.cs
@@ -6,6 +6,7 @@
         public GlobParseOptions()
         {
             AllowInvalidPathCharacters = false;
+            CaseInsensitive = false;
         }
 
         public static GlobParseOptions Default = new GlobParseOptions();
@@ -15,7 +16,7 @@
         /// If you are comparing to arbitrary text and not file or directory paths, then you should set this to true.
         /// </summary>
         public bool AllowInvalidPathCharacters { get; set; }
-
-       
+        
+        public bool CaseInsensitive { get; set; }
     }
 }

--- a/src/DotNet.Glob/GlobStringReader.cs
+++ b/src/DotNet.Glob/GlobStringReader.cs
@@ -147,22 +147,6 @@ namespace DotNet.Globbing
         }
 
         /// <summary>
-        /// Does current character match the character argument
-        /// </summary>
-        public bool IsCurrentCharEqualTo(char comparisonChar)
-        {
-            return IsCharEqualTo(CurrentChar, comparisonChar);
-        }
-
-        /// <summary>
-        /// Are the arguments the same character, ignoring case
-        /// </summary>
-        public static bool IsCharEqualTo(char comparisonChar, char compareTo)
-        {
-            return char.ToLowerInvariant(comparisonChar) == char.ToLowerInvariant(compareTo);
-        }
-
-        /// <summary>
         /// Is current character WhiteSpace
         /// </summary>
         public bool IsWhiteSpace
@@ -218,8 +202,8 @@ namespace DotNet.Globbing
         public static bool IsPathSeperator(char character)
         {
 
-            var isCurrentCharacterStartOfDelimiter = IsCharEqualTo(character, PathSeperators[0]) ||
-                                                     IsCharEqualTo(character, PathSeperators[1]);
+            var isCurrentCharacterStartOfDelimiter = character == PathSeperators[0] ||
+                                                     character == PathSeperators[1];
 
             return isCurrentCharacterStartOfDelimiter;
 

--- a/src/DotNet.Glob/IGlobBuilder.cs
+++ b/src/DotNet.Glob/IGlobBuilder.cs
@@ -16,7 +16,7 @@ namespace DotNet.Globbing
         IGlobBuilder LetterNotInRange(char start, char end);
         IGlobBuilder NumberInRange(char start, char end);
         IGlobBuilder NumberNotInRange(char start, char end);
-        Glob ToGlob();
+        Glob ToGlob(GlobOptions options = null);
         List<IGlobToken> Tokens { get; }
     }
 

--- a/src/DotNet.Glob/ParsingOptions.cs
+++ b/src/DotNet.Glob/ParsingOptions.cs
@@ -1,22 +1,16 @@
 ﻿namespace DotNet.Globbing
 {
-    public class GlobParseOptions
+    public class ParsingOptions
     {
-
-        public GlobParseOptions()
+        public ParsingOptions()
         {
             AllowInvalidPathCharacters = false;
-            CaseInsensitive = false;
         }
-
-        public static GlobParseOptions Default = new GlobParseOptions();
 
         /// <summary>
         /// If true, allows non standard alpha-numeric characters that aren't valid for file system / directory paths, to be present in the token string.
         /// If you are comparing to arbitrary text and not file or directory paths, then you should set this to true.
         /// </summary>
         public bool AllowInvalidPathCharacters { get; set; }
-        
-        public bool CaseInsensitive { get; set; }
     }
 }

--- a/src/DotNet.Glob/Token/CharacterListToken.cs
+++ b/src/DotNet.Glob/Token/CharacterListToken.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace DotNet.Globbing.Token
 {
     public class CharacterListToken : INegatableToken
     {
+        private List<char> _charactersInvariantLowerCase;
+
         public CharacterListToken(char[] characters, bool isNegated)
         {
             Characters = new List<char>(characters);
+            _charactersInvariantLowerCase = null;
             //  Characters = characters; // 
             IsNegated = isNegated;
         }
@@ -16,7 +19,18 @@ namespace DotNet.Globbing.Token
 
         //  public Char[] Characters { get; set; }
 
-        public List<Char> Characters { get; set; }
+        public List<char> Characters { get; }
+
+        public List<char> CharactersInvariantLowerCase
+        {
+            get
+            {
+                // initialize on first use (indicates case insensitive matching)
+                if (_charactersInvariantLowerCase == null)
+                    _charactersInvariantLowerCase = new List<char>(this.Characters.Select(c => char.ToLowerInvariant(c)));
+                return _charactersInvariantLowerCase;
+            }
+        }
 
         public void Accept(IGlobTokenVisitor Visitor)
         {

--- a/src/DotNet.Glob/Token/CharacterListToken.cs
+++ b/src/DotNet.Glob/Token/CharacterListToken.cs
@@ -1,41 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace DotNet.Globbing.Token
+﻿namespace DotNet.Globbing.Token
 {
     public class CharacterListToken : INegatableToken
     {
-        private List<char> _charactersInvariantLowerCase;
-
         public CharacterListToken(char[] characters, bool isNegated)
         {
-            Characters = new List<char>(characters);
-            _charactersInvariantLowerCase = null;
-            //  Characters = characters; // 
+            Characters = characters; // new List<char>(characters);                
             IsNegated = isNegated;
         }
-        public bool IsNegated { get; set; }
 
-        //  public Char[] Characters { get; set; }
+        public bool IsNegated { get; set; }      
 
-        public List<char> Characters { get; }
-
-        public List<char> CharactersInvariantLowerCase
-        {
-            get
-            {
-                // initialize on first use (indicates case insensitive matching)
-                if (_charactersInvariantLowerCase == null)
-                    _charactersInvariantLowerCase = new List<char>(this.Characters.Select(c => char.ToLowerInvariant(c)));
-                return _charactersInvariantLowerCase;
-            }
-        }
+        public char[] Characters { get; }       
 
         public void Accept(IGlobTokenVisitor Visitor)
         {
             Visitor.Visit(this);
         }
-
     }
 }


### PR DESCRIPTION
Fix for #41. Implemented as `CaseInsensitive` property on GlobParseOptions - although I'd say it's more an evaluator/matching option. But that's just naming, I'll let you decide what you think is best here.

In the end, only the `bool caseInsensitive` itself is passed to Evaluator constructors where applicable. They use `ToLowerInvariant` on the fly before comparing, if case insensitivity is switched on.

CharacterListTokens, however, are a special case where, from a performance perspective, it would make sense to cache a list of tokens in their *lower (invariant)* form, since lookups are performed on this list for each character in the input string. Unsure whether caching vs no caching *really* makes a difference in most cases, though.

A note about "insensitivity" vs "sensitivity": it felt more natural to **switch on insensitivity**, rather than **switching off sensitivity**, due to the current default behaviour as well as how e.g. regular expressions work (where an insensitivity switch is required).

Removed `IsCurrentCharEqualTo` from GlobStringReader: it did case-insensitive (ToLowerInvariant) comparison of chars, which was unnecessary (only compared to path seperators) and confusing. Removed it and replaced with regular `==` comparison.

Added regression tests (IsMatchCaseInsensitive and added inline data to Does_Not_Match) - all tests passing. Don't currently have time to create benchmark tests that take case insensitivity into account. Hope you'll be able to assist here.

Let me know what you think.