### PR TITLE
Fixed match: abc** should match abc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In addition, DotNet Glob also supports:
 
 | Wildcard  | Description | Example | Matches | Does not match |
 | --------  | ----------- | ------- | ------- | -------------- |
-| `**` |  matches any number of path / directory segments. When used must be the only contents of a segment. | /\*\*/some.\* | /foo/bar/bah/some.txt, /some.txt, or /foo/some.txt	|
+| `**` |  matches zero or more path / directory segments. When used must be the only contents of a segment. | /\*\*/some.\* | /foo/bar/bah/some.txt, /some.txt, or /foo/some.txt	|
 
 
 # Escaping special characters

--- a/src/DotNet.Glob.Tests/GlobTests.cs
+++ b/src/DotNet.Glob.Tests/GlobTests.cs
@@ -88,7 +88,9 @@ namespace DotNet.Glob.Tests
         [InlineData(@"abc/**", @"abc/def/hij.txt")]
         [InlineData(@"a/**/b", "a/b")] // Regression Test for https://github.com/dazinator/DotNet.Glob/issues/65
         [InlineData(@"abc/**", "abc/def")] // Regression Test for https://github.com/dazinator/DotNet.Glob/issues/65
-        public void IsMatch(string pattern, params string[] testStrings)
+		[InlineData(@"abc**", "abc")]
+		[InlineData(@"**abc", "abc")]
+		public void IsMatch(string pattern, params string[] testStrings)
         {
             var glob = Globbing.Glob.Parse(pattern);
             foreach (var testString in testStrings)

--- a/src/DotNet.Glob/Evaluation/WildcardDirectoryTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/WildcardDirectoryTokenEvaluator.cs
@@ -33,9 +33,10 @@ namespace DotNet.Globbing.Evaluation
             newPosition = currentPosition;          
 
             // A) If leading seperator then current character needs to be that seperator.
-            if(allChars.Length <= currentPosition || currentPosition < 0)
+			if (allChars.Length <= currentPosition || currentPosition < 0)
             {
-                return false;
+				//There is no more characters, if there is no leading path separator, we match.
+                return _token.LeadingPathSeparator == null;
             }
             char currentChar = allChars[currentPosition];
             if (_token.LeadingPathSeparator != null)


### PR DESCRIPTION
Hi,
It try to fix that abc** actually does not match with abc but it should.
I also changed the wording of the wildcard \*\* in the readme to give no doubt that \*\* can match **0** or more directory.