### PR TITLE
Support for ReadOnlySpan<char> prior to .NET Standard 2.1

### DIFF
--- a/src/DotNet.Glob.Tests/DotNet.Glob.Tests.csproj
+++ b/src/DotNet.Glob.Tests/DotNet.Glob.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--<TargetFrameworks>netcoreapp1.1;netcoreapp2.1</TargetFrameworks>-->
+    <!--<TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>-->
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>DotNet.Glob.Tests</AssemblyName>
     <PackageId>DotNet.Glob.Tests</PackageId>
@@ -14,7 +14,7 @@
     <AssemblyOriginatorKeyFile>..\..\Dotnet.Glob.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="  '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <PropertyGroup Condition="  '$(TargetFramework)' != 'net4' ">
     <DefineConstants>SPAN</DefineConstants>
   </PropertyGroup>
 

--- a/src/DotNet.Glob/DotNet.Glob.csproj
+++ b/src/DotNet.Glob/DotNet.Glob.csproj
@@ -18,7 +18,7 @@
     <DefineConstants>NET40</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="  '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <PropertyGroup Condition="  '$(TargetFramework)' != 'net4'  ">
     <DefineConstants>SPAN</DefineConstants>
   </PropertyGroup>
 
@@ -27,6 +27,10 @@
     <AssemblyOriginatorKeyFile>..\..\Dotnet.Glob.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
- 
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net4' And '$(TargetFramework)' != 'netcoreapp2.1' ">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/DotNet.Glob/DotNet.Glob.csproj
+++ b/src/DotNet.Glob/DotNet.Glob.csproj
@@ -27,7 +27,7 @@
     <AssemblyOriginatorKeyFile>..\..\Dotnet.Glob.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net4' And '$(TargetFramework)' != 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net4' And '$(TargetFramework)' != 'netcoreapp2.1' And '$(TargetFramework)' != 'netstandard2.1' ">
     <PackageReference Include="System.Memory">
       <Version>4.5.0</Version>
     </PackageReference>

--- a/src/DotNet.Glob/Evaluation/AnyCharacterTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/AnyCharacterTokenEvaluator.cs
@@ -12,10 +12,12 @@ namespace DotNet.Globbing.Evaluation
             _token = token;
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             newPosition = currentPosition + 1;

--- a/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluator.cs
@@ -15,10 +15,12 @@ namespace DotNet.Globbing.Evaluation
             _token = token;
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             var currentChar = allChars[currentPosition];

--- a/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/CharacterListTokenEvaluatorCaseInsensitive.cs
@@ -22,10 +22,12 @@ namespace DotNet.Globbing.Evaluation
             }
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             var currentChar = allChars[currentPosition];

--- a/src/DotNet.Glob/Evaluation/CompositeTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/CompositeTokenEvaluator.cs
@@ -86,10 +86,12 @@ namespace DotNet.Globbing.Evaluation
             _finished = true; // signlas to stop visiting any further tokens as we have offloaded them all to the nested evaluator.
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             newPosition = currentPosition;

--- a/src/DotNet.Glob/Evaluation/IGlobTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/IGlobTokenEvaluator.cs
@@ -7,9 +7,8 @@ namespace DotNet.Globbing.Evaluation
 
 #if SPAN
         bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition);
-#else
-        bool IsMatch(string allChars, int currentPosition, out int newPosition);
 #endif
+        bool IsMatch(string allChars, int currentPosition, out int newPosition);
 
         int ConsumesMinLength { get; }
         bool ConsumesVariableLength { get; }

--- a/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluator.cs
@@ -5,22 +5,24 @@ using System.Runtime.CompilerServices;
 namespace DotNet.Globbing.Evaluation
 {
     public class LetterRangeTokenEvaluator : IGlobTokenEvaluator
-    {     
+    {
         private readonly LetterRangeToken _token;
 
         public LetterRangeTokenEvaluator(LetterRangeToken token)
-        {          
+        {
             _token = token;
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
-            newPosition = currentPosition + 1;           
-            char currentChar;          
+            newPosition = currentPosition + 1;
+            char currentChar;
             currentChar = allChars[currentPosition];
             return IsMatch(currentChar);
         }

--- a/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/LetterRangeTokenEvaluatorCaseInsensitive.cs
@@ -21,10 +21,12 @@ namespace DotNet.Globbing.Evaluation
             _endLowerInvariant = char.ToLowerInvariant(token.End);
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             newPosition = currentPosition + 1;

--- a/src/DotNet.Glob/Evaluation/LiteralTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/LiteralTokenEvaluator.cs
@@ -14,12 +14,14 @@ namespace DotNet.Globbing.Evaluation
             _token = token;           
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
-#endif
+#if SPAN
         {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
+ #endif
+       {
             newPosition = currentPosition;
             int counter = 0;
 

--- a/src/DotNet.Glob/Evaluation/LiteralTokenEvaluatorCaseInsensitive.cs
+++ b/src/DotNet.Glob/Evaluation/LiteralTokenEvaluatorCaseInsensitive.cs
@@ -16,12 +16,14 @@ namespace DotNet.Globbing.Evaluation
             _literalAsUpperInvariant = token.Value.ToUpperInvariant();
         }
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
-#endif
         {
+#if SPAN
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
+        {
+#endif
             newPosition = currentPosition;
             int counter = 0;
 

--- a/src/DotNet.Glob/Evaluation/NumberRangeTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/NumberRangeTokenEvaluator.cs
@@ -11,10 +11,12 @@ namespace DotNet.Globbing.Evaluation
         {
             _token = token;
         }
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             var currentChar = allChars[currentPosition];

--- a/src/DotNet.Glob/Evaluation/PathSeparatorTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/PathSeparatorTokenEvaluator.cs
@@ -12,10 +12,12 @@ namespace DotNet.Globbing.Evaluation
         {
             _token = token;
         }
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             var currentChar = allChars[currentPosition];

--- a/src/DotNet.Glob/Evaluation/WildcardDirectoryTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/WildcardDirectoryTokenEvaluator.cs
@@ -18,14 +18,16 @@ namespace DotNet.Globbing.Evaluation
 
         #region IGlobTokenEvaluator
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
             // We shortcut to success for a ** in some special cases:-
-               //  1. The remaining tokens don't need to consume a minimum number of chracters in order to match.
+            //  1. The remaining tokens don't need to consume a minimum number of chracters in order to match.
 
             // We shortcut to failure for a ** in some special cases:-
             // A) The token was parsed with a leading path separator (i.e '/**' and the current charater we are matching from isn't a path separator.

--- a/src/DotNet.Glob/Evaluation/WildcardTokenEvaluator.cs
+++ b/src/DotNet.Glob/Evaluation/WildcardTokenEvaluator.cs
@@ -20,10 +20,12 @@ namespace DotNet.Globbing.Evaluation
 
         #region IGlobTokenEvaluator
 
-#if SPAN
-        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
-#else
         public bool IsMatch(string allChars, int currentPosition, out int newPosition)
+#if SPAN
+        {
+            return IsMatch(allChars.AsSpan(), currentPosition, out newPosition);
+        }
+        public bool IsMatch(ReadOnlySpan<char> allChars, int currentPosition, out int newPosition)
 #endif
         {
 


### PR DESCRIPTION
I'm using `ReadOnlySpan<char>` in .NET FW4.8 with a [Nuget backport](https://www.nuget.org/packages/System.Memory/).
I tried to use this good looking library, but I couldn't get `ReadOnlySpan<char>` to work.

So I changed it to allow `ReadOnlySpan<char>` to be used outside of `net4`.
I've also kept the overload for `string` for compatibility.

**Notice: this PR changes the dependencies.**
